### PR TITLE
Allow arbitrary granularity in queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ example output:
 example input:
 ```Java
 List<String> intervals = Collections.singletonList("2012-01-01T00:00:00.000/2012-01-03T00:00:00.000");
-Granularity granularity = Granularity.day;
+Granularity granularity = SimpleGranularity.day;
 List<DimensionSpec> dimensionSpecs = new ArrayList<DimensionSpec>() {{
     add(new DefaultDimension().setDimension("country"));
     add(new DefaultDimension().setDimension("device"));
@@ -156,7 +156,7 @@ example output:
 example input:
 ```Java
 List<String> intervals = Collections.singletonList("2012-01-01T00:00:00.000/2012-01-03T00:00:00.000");
-Granularity granularity = Granularity.day;
+Granularity granularity = SimpleGranularity.day;
 SearchQuerySpec searchQuerySpec = new ContainsSearchQuerySpec().setCase_sensitive(true).setValue("sample_value");
 
 SearchQuery query = new SearchQuery(new TableDataSource("sample_datasource"), intervals, granularity, searchQuerySpec)
@@ -291,7 +291,7 @@ example output:
 example input: 
 ```Java
 List<String> intervals = Collections.singletonList("2012-01-01T00:00:00.000/2012-01-03T00:00:00.000");
-Granularity granularity = Granularity.day;
+Granularity granularity = SimpleGranularity.day;
 List<Aggregation> aggregations = new ArrayList<Aggregation>() {{
     add(new LongSumAggregation().setFieldName("sample_fieldName1").setName("sample_name1"));
     add(new DoubleSumAggregation().setFieldName("sample_fieldName2").setName("sample_name2"));
@@ -376,7 +376,7 @@ example output:
 example input:
 ```Java
 List<String> intervals = Collections.singletonList("2013-08-31T00:00:00.000/2013-09-03T00:00:00.000");
-Granularity granularity = Granularity.all;
+Granularity granularity = SimpleGranularity.all;
 DimensionSpec dimension = new DefaultDimension().setDimension("sample_dim");
 int threshold = 5;
 TopNMetricSpec topNMetricSpec = new NumericTopNMetricSpec("count");

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.salecycle</groupId>
     <artifactId>moonfire</artifactId>
-    <version>0.4.5-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Moonfire</name>
     <description>A java library for crafting Druid queries</description>

--- a/src/main/java/com/salecycle/moonfire/queries/models/granularities/ComplexGranularity.java
+++ b/src/main/java/com/salecycle/moonfire/queries/models/granularities/ComplexGranularity.java
@@ -1,6 +1,6 @@
 package com.salecycle.moonfire.queries.models.granularities;
 
-public abstract class ComplexGranularity {
+public abstract class ComplexGranularity implements Granularity {
     private String type;
     private String origin;
 
@@ -16,7 +16,8 @@ public abstract class ComplexGranularity {
         return origin;
     }
 
-    public void setOrigin(String origin) {
+    public ComplexGranularity setOrigin(String origin) {
         this.origin = origin;
+        return this;
     }
 }

--- a/src/main/java/com/salecycle/moonfire/queries/models/granularities/Granularity.java
+++ b/src/main/java/com/salecycle/moonfire/queries/models/granularities/Granularity.java
@@ -1,5 +1,7 @@
 package com.salecycle.moonfire.queries.models.granularities;
 
-public enum Granularity {
-    all, none, second, minute, fifteen_minute, thirty_minute, hour, day, week, month, quarter, year
+/**
+ * Marker interface for Druid query granularities.
+ */
+public interface Granularity {
 }

--- a/src/main/java/com/salecycle/moonfire/queries/models/granularities/SimpleGranularity.java
+++ b/src/main/java/com/salecycle/moonfire/queries/models/granularities/SimpleGranularity.java
@@ -1,0 +1,5 @@
+package com.salecycle.moonfire.queries.models.granularities;
+
+public enum SimpleGranularity implements Granularity {
+    all, none, second, minute, fifteen_minute, thirty_minute, hour, day, week, month, quarter, year
+}

--- a/src/test/java/com/salecycle/moonfire/queries/QueryTypeCheckTest.java
+++ b/src/test/java/com/salecycle/moonfire/queries/QueryTypeCheckTest.java
@@ -3,7 +3,7 @@ package com.salecycle.moonfire.queries;
 import com.salecycle.moonfire.queries.models.datasources.TableDataSource;
 import com.salecycle.moonfire.queries.models.dimensionspecs.DefaultDimension;
 import com.salecycle.moonfire.queries.models.dimensionspecs.DimensionSpec;
-import com.salecycle.moonfire.queries.models.granularities.Granularity;
+import com.salecycle.moonfire.queries.models.granularities.SimpleGranularity;
 import com.salecycle.moonfire.queries.models.searchqueryspecs.ContainsSearchQuerySpec;
 import com.salecycle.moonfire.queries.models.topnmetricspecs.NumericTopNMetricSpec;
 import org.junit.Test;
@@ -16,11 +16,11 @@ public class QueryTypeCheckTest {
     @Test
     public void typeCheck() {
         assertEquals("dataSourceMetadata", new DataSourceMetadataQuery(new TableDataSource("dataSource")).getQueryType());
-        assertEquals("timeseries", new TimeSeriesQuery(new TableDataSource("dataSource"), Collections.<String>emptyList(), Granularity.all).getQueryType());
-        assertEquals("topN", new TopNQuery(new TableDataSource("dataSource"), Collections.<String>emptyList(), Granularity.all, new DefaultDimension(), 1, new NumericTopNMetricSpec("metric")).getQueryType());
-        assertEquals("groupBy", new GroupByQuery(new TableDataSource("dataSource"), Collections.<String>emptyList(), Granularity.all, Collections.<DimensionSpec>emptyList()).getQueryType());
+        assertEquals("timeseries", new TimeSeriesQuery(new TableDataSource("dataSource"), Collections.<String>emptyList(), SimpleGranularity.all).getQueryType());
+        assertEquals("topN", new TopNQuery(new TableDataSource("dataSource"), Collections.<String>emptyList(), SimpleGranularity.all, new DefaultDimension(), 1, new NumericTopNMetricSpec("metric")).getQueryType());
+        assertEquals("groupBy", new GroupByQuery(new TableDataSource("dataSource"), Collections.<String>emptyList(), SimpleGranularity.all, Collections.<DimensionSpec>emptyList()).getQueryType());
         assertEquals("timeBoundary", new TimeBoundaryQuery(new TableDataSource("dataSource")).getQueryType());
         assertEquals("segmentMetadata", new SegmentMetadataQuery(new TableDataSource("dataSource")).getQueryType());
-        assertEquals("search", new SearchQuery(new TableDataSource("dataSource"), Collections.<String>emptyList(), Granularity.all, new ContainsSearchQuerySpec()).getQueryType());
+        assertEquals("search", new SearchQuery(new TableDataSource("dataSource"), Collections.<String>emptyList(), SimpleGranularity.all, new ContainsSearchQuerySpec()).getQueryType());
     }
 }

--- a/src/test/java/com/salecycle/moonfire/queries/SearchQueryTest.java
+++ b/src/test/java/com/salecycle/moonfire/queries/SearchQueryTest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.salecycle.moonfire.queries.models.Ordering;
 import com.salecycle.moonfire.queries.models.datasources.TableDataSource;
-import com.salecycle.moonfire.queries.models.granularities.Granularity;
+import com.salecycle.moonfire.queries.models.granularities.SimpleGranularity;
 import com.salecycle.moonfire.queries.models.searchqueryspecs.ContainsSearchQuerySpec;
 import com.salecycle.moonfire.queries.models.searchqueryspecs.SearchQuerySpec;
 import org.junit.Test;
@@ -24,7 +24,7 @@ public class SearchQueryTest {
         ObjectWriter writer = mapper.writerFor(SearchQuery.class);
 
         List<String> intervals = Collections.singletonList("2012-01-01T00:00:00.000/2012-01-03T00:00:00.000");
-        Granularity granularity = Granularity.day;
+        SimpleGranularity granularity = SimpleGranularity.day;
         SearchQuerySpec searchQuerySpec = new ContainsSearchQuerySpec().setCase_sensitive(true).setValue("sample_value");
 
         SearchQuery query = new SearchQuery(new TableDataSource("sample_datasource"), intervals, granularity, searchQuerySpec)

--- a/src/test/java/com/salecycle/moonfire/queries/TimeSeriesQueryTest.java
+++ b/src/test/java/com/salecycle/moonfire/queries/TimeSeriesQueryTest.java
@@ -14,6 +14,8 @@ import com.salecycle.moonfire.queries.models.filters.Filter;
 import com.salecycle.moonfire.queries.models.filters.OrFilter;
 import com.salecycle.moonfire.queries.models.filters.SelectorFilter;
 import com.salecycle.moonfire.queries.models.granularities.Granularity;
+import com.salecycle.moonfire.queries.models.granularities.PeriodGranularity;
+import com.salecycle.moonfire.queries.models.granularities.SimpleGranularity;
 import com.salecycle.moonfire.queries.models.postaggregations.ArithmeticPostAggregation;
 import com.salecycle.moonfire.queries.models.postaggregations.FieldAccessPostAggregation;
 import com.salecycle.moonfire.queries.models.postaggregations.PostAggregation;
@@ -35,7 +37,7 @@ public class TimeSeriesQueryTest {
         ObjectWriter writer = mapper.writerFor(TimeSeriesQuery.class);
 
         List<String> intervals = Collections.singletonList("2012-01-01T00:00:00.000/2012-01-03T00:00:00.000");
-        Granularity granularity = Granularity.day;
+        SimpleGranularity granularity = SimpleGranularity.day;
         List<VirtualColumn> virtualColumns = new ArrayList<VirtualColumn>() {{
             add(new ExpressionVirtualColumn().setName("value").setExpression("if(id!='myId', 0, value)").setOutputType(OutputType.FLOAT));
         }};
@@ -73,6 +75,112 @@ public class TimeSeriesQueryTest {
                 "    \"name\" : \"sample_datasource\"\n" +
                 "  },\n" +
                 "  \"granularity\" : \"day\",\n" +
+                "  \"descending\" : true,\n" +
+                "  \"virtualColumns\" : [ {\n" +
+                "    \"type\" : \"expression\",\n" +
+                "    \"name\" : \"value\",\n" +
+                "    \"expression\" : \"if(id!='myId', 0, value)\",\n" +
+                "    \"outputType\" : \"FLOAT\"\n" +
+                "  } ],\n" +
+                "  \"intervals\" : [ \"2012-01-01T00:00:00.000/2012-01-03T00:00:00.000\" ],\n" +
+                "  \"filter\" : {\n" +
+                "    \"type\" : \"and\",\n" +
+                "    \"fields\" : [ {\n" +
+                "      \"type\" : \"selector\",\n" +
+                "      \"dimension\" : \"sample_dimension1\",\n" +
+                "      \"value\" : \"sample_value1\"\n" +
+                "    }, {\n" +
+                "      \"type\" : \"or\",\n" +
+                "      \"fields\" : [ {\n" +
+                "        \"type\" : \"selector\",\n" +
+                "        \"dimension\" : \"sample_dimension2\",\n" +
+                "        \"value\" : \"sample_value2\"\n" +
+                "      }, {\n" +
+                "        \"type\" : \"selector\",\n" +
+                "        \"dimension\" : \"sample_dimension3\",\n" +
+                "        \"value\" : \"sample_value3\"\n" +
+                "      } ]\n" +
+                "    } ]\n" +
+                "  },\n" +
+                "  \"aggregations\" : [ {\n" +
+                "    \"type\" : \"longSum\",\n" +
+                "    \"name\" : \"sample_name1\",\n" +
+                "    \"fieldName\" : \"sample_fieldName1\"\n" +
+                "  }, {\n" +
+                "    \"type\" : \"doubleSum\",\n" +
+                "    \"name\" : \"sample_name2\",\n" +
+                "    \"fieldName\" : \"sample_fieldName2\"\n" +
+                "  } ],\n" +
+                "  \"postAggregations\" : [ {\n" +
+                "    \"type\" : \"arithmetic\",\n" +
+                "    \"name\" : \"sample_divide\",\n" +
+                "    \"fn\" : \"/\",\n" +
+                "    \"fields\" : [ {\n" +
+                "      \"type\" : \"fieldAccess\",\n" +
+                "      \"name\" : \"postAgg__sample_name1\",\n" +
+                "      \"fieldName\" : \"sample_name1\"\n" +
+                "    }, {\n" +
+                "      \"type\" : \"fieldAccess\",\n" +
+                "      \"name\" : \"postAgg__sample_name2\",\n" +
+                "      \"fieldName\" : \"sample_name2\"\n" +
+                "    } ]\n" +
+                "  } ]\n" +
+                "}";
+        assertEquals(expected, json);
+    }
+
+    @Test
+    public void serialisationComplexGranularity() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        ObjectWriter writer = mapper.writerFor(TimeSeriesQuery.class);
+
+        List<String> intervals = Collections.singletonList("2012-01-01T00:00:00.000/2012-01-03T00:00:00.000");
+        Granularity granularity = new PeriodGranularity()
+            .setPeriod("P3M")
+            .setTimeZone("America/Los_Angeles")
+            .setOrigin("2012-02-01T00:00:00-08:00");
+        List<VirtualColumn> virtualColumns = new ArrayList<VirtualColumn>() {{
+            add(new ExpressionVirtualColumn().setName("value").setExpression("if(id!='myId', 0, value)").setOutputType(OutputType.FLOAT));
+        }};
+        List<Aggregation> aggregations = new ArrayList<Aggregation>() {{
+            add(new LongSumAggregation().setFieldName("sample_fieldName1").setName("sample_name1"));
+            add(new DoubleSumAggregation().setFieldName("sample_fieldName2").setName("sample_name2"));
+        }};
+        List<PostAggregation> fields = new ArrayList<PostAggregation>() {{
+            add(new FieldAccessPostAggregation().setFieldName("sample_name1").setName("postAgg__sample_name1"));
+            add(new FieldAccessPostAggregation().setFieldName("sample_name2").setName("postAgg__sample_name2"));
+        }};
+        List<PostAggregation> postAggregations = new ArrayList<PostAggregation>() {{
+            add(new ArithmeticPostAggregation().setFn("/").setFields(fields).setName("sample_divide"));
+        }};
+        Filter filter = new AndFilter()
+            .addField(new SelectorFilter().setDimension("sample_dimension1").setValue("sample_value1"))
+            .addField(new OrFilter()
+                .addField(new SelectorFilter().setDimension("sample_dimension2").setValue("sample_value2"))
+                .addField(new SelectorFilter().setDimension("sample_dimension3").setValue("sample_value3"))
+            );
+
+        TimeSeriesQuery query = new TimeSeriesQuery(new TableDataSource("sample_datasource"), intervals, granularity)
+            .setDescending(true)
+            .setFilter(filter)
+            .setVirtualColumns(virtualColumns)
+            .setAggregations(aggregations)
+            .setPostAggregations(postAggregations);
+
+        String json = writer.withDefaultPrettyPrinter().writeValueAsString(query);
+        String expected =
+            "{\n" +
+                "  \"queryType\" : \"timeseries\",\n" +
+                "  \"dataSource\" : {\n" +
+                "    \"type\" : \"table\",\n" +
+                "    \"name\" : \"sample_datasource\"\n" +
+                "  },\n" +
+                "  \"granularity\" : {\n" +
+                "    \"type\" : \"period\",\n" +
+                "    \"origin\" : \"2012-02-01T00:00:00-08:00\",\n" +
+                "    \"period\" : \"P3M\",\n" +
+                "    \"timeZone\" : \"America/Los_Angeles\"\n" +
+                "  },\n" +
                 "  \"descending\" : true,\n" +
                 "  \"virtualColumns\" : [ {\n" +
                 "    \"type\" : \"expression\",\n" +

--- a/src/test/java/com/salecycle/moonfire/queries/TopNQueryTest.java
+++ b/src/test/java/com/salecycle/moonfire/queries/TopNQueryTest.java
@@ -14,7 +14,7 @@ import com.salecycle.moonfire.queries.models.dimensionspecs.DimensionSpec;
 import com.salecycle.moonfire.queries.models.filters.AndFilter;
 import com.salecycle.moonfire.queries.models.filters.Filter;
 import com.salecycle.moonfire.queries.models.filters.SelectorFilter;
-import com.salecycle.moonfire.queries.models.granularities.Granularity;
+import com.salecycle.moonfire.queries.models.granularities.SimpleGranularity;
 import com.salecycle.moonfire.queries.models.postaggregations.ArithmeticPostAggregation;
 import com.salecycle.moonfire.queries.models.postaggregations.FieldAccessPostAggregation;
 import com.salecycle.moonfire.queries.models.postaggregations.PostAggregation;
@@ -38,7 +38,7 @@ public class TopNQueryTest {
         ObjectWriter writer = mapper.writerFor(TopNQuery.class);
 
         List<String> intervals = Collections.singletonList("2013-08-31T00:00:00.000/2013-09-03T00:00:00.000");
-        Granularity granularity = Granularity.all;
+        SimpleGranularity granularity = SimpleGranularity.all;
         DimensionSpec dimension = new DefaultDimension().setDimension("sample_dim");
         int threshold = 5;
         TopNMetricSpec topNMetricSpec = new NumericTopNMetricSpec("count");

--- a/src/test/java/com/salecycle/moonfire/queries/datasources/TypeCheckTest.java
+++ b/src/test/java/com/salecycle/moonfire/queries/datasources/TypeCheckTest.java
@@ -4,7 +4,7 @@ import com.salecycle.moonfire.queries.GroupByQuery;
 import com.salecycle.moonfire.queries.models.datasources.GroupByQueryDataSource;
 import com.salecycle.moonfire.queries.models.datasources.TableDataSource;
 import com.salecycle.moonfire.queries.models.datasources.UnionDataSource;
-import com.salecycle.moonfire.queries.models.granularities.Granularity;
+import com.salecycle.moonfire.queries.models.granularities.SimpleGranularity;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertEquals;
 public class TypeCheckTest {
     @Test
     public void TypeCheck() {
-        GroupByQuery groupByQuery = new GroupByQuery(new TableDataSource("sample_datasource"), Collections.emptyList(), Granularity.all, Collections.emptyList());
+        GroupByQuery groupByQuery = new GroupByQuery(new TableDataSource("sample_datasource"), Collections.emptyList(), SimpleGranularity.all, Collections.emptyList());
         assertEquals("query", new GroupByQueryDataSource(groupByQuery).getType());
         assertEquals("table", new TableDataSource("sample_datasource").getType());
         assertEquals("union", new UnionDataSource(Collections.emptyList()).getType());


### PR DESCRIPTION
* Add a common interface for granularity classes.  The current `Granularity` enum and `ComplexGranularity`, `PeriodGranularity` classes implement a common interface used in queries.